### PR TITLE
Indicate that GCS adapter can overwrite file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.0",
         "google/cloud-storage": "^1.3",
-        "league/flysystem": "^1.0"
+        "league/flysystem": "^1.0.40"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0|~6.0"

--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -8,6 +8,7 @@ use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\StorageObject;
 use Google\Cloud\Storage\StorageClient;
 use League\Flysystem\Adapter\AbstractAdapter;
+use League\Flysystem\Adapter\CanOverwriteFiles;
 use League\Flysystem\Adapter\Polyfill\StreamedReadingTrait;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
@@ -21,7 +22,7 @@ use League\Flysystem\Config;
  *
  * @see AdapterInterface
  */
-class GoogleCloudStorageAdapter extends AbstractAdapter
+class GoogleCloudStorageAdapter extends AbstractAdapter implements CanOverwriteFiles
 {
     use StreamedReadingTrait;
 


### PR DESCRIPTION
This PR implements the interface `\League\Flysystem\Adapter\CanOverwriteFiles` for `GoogleCloudStorageAdapter` to optimize away a `Filesystem::has` call. It looks like this in `\League\Flysystem\Filesystem`:

```php

        if ( ! $this->getAdapter() instanceof CanOverwriteFiles && $this->has($path)) {
            return (bool) $this->getAdapter()->updateStream($path, $resource, $config);
        }

```