### PR TITLE
Adapter::has should check if a directory object exists

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -288,7 +288,13 @@ class GoogleCloudStorageAdapter extends AbstractAdapter implements CanOverwriteF
         $path = $this->applyPathPrefix($path);
         $object = $this->bucket->object($path);
 
-        return $object->exists();
+        if ($object->exists()) {
+            return true;
+        }
+
+        // flysystem strips trailing slashes so we need to check
+        // for directory objects
+        return $this->bucket->object(sprintf('%s/', $path))->exists();
     }
 
     /**

--- a/tests/GoogleCloudStorageAdapterTest.php
+++ b/tests/GoogleCloudStorageAdapterTest.php
@@ -513,4 +513,26 @@ class GoogleCloudStorageAdapterTest extends TestCase
 
         self::assertEquals(sprintf('%s/%s/%s', GoogleCloudStorageAdapter::GCS_BASE_URL, $adapterConfig['bucket'], $objectName), $url);
     }
+
+    /**
+     * @see https://github.com/cedricziel/flysystem-gcs/issues/11
+     *
+     * @covers \CedricZiel\FlysystemGcs\GoogleCloudStorageAdapter::has()
+     */
+    public function testHasWorksCorrectlyForDirectories(): void
+    {
+        $testId = uniqid('', true);
+        $adapterConfig = [
+            'bucket' => $this->bucket,
+            'projectId' => $this->project,
+        ];
+
+        $directoryName = sprintf('%s', sprintf('icon-%s', $testId));
+
+        $adapter = new GoogleCloudStorageAdapter(null, $adapterConfig);
+        $fs = new Filesystem($adapter);
+        $fs->createDir($directoryName);
+
+        self::assertTrue($fs->has($directoryName));
+    }
 }


### PR DESCRIPTION
This fixes an issue where Flysystem would strip trailing slashes from the object path.

Fixes: #11